### PR TITLE
Update snap pack url regex

### DIFF
--- a/lib/lob/models/snap_pack.rb
+++ b/lib/lob/models/snap_pack.rb
@@ -284,7 +284,7 @@ module Lob
         invalid_properties.push('invalid value for "url", url cannot be nil.')
       end
 
-      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(_signature)?(\.pdf|_thumb_[a-z]+_[0-9]+\.png|\.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+/)
+      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(order-creatives|letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}([a-z0-9]{10})(_[a-z]{4}_[a-z0-9]{25})(_signature)?(\.pdf|_thumb_[a-z]+_[0-9]+\.png|\.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+/)
       if @url !~ pattern
         invalid_properties.push("invalid value for \"url\", must conform to the pattern #{pattern}.")
       end
@@ -305,7 +305,7 @@ module Lob
       object_validator = EnumAttributeValidator.new('String', ["snap_pack"])
       return false unless object_validator.valid?(@object)
       return false if @url.nil?
-      return false if @url !~ Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(_signature)?(\.pdf|_thumb_[a-z]+_[0-9]+\.png|\.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+/)
+      return false if @url !~ Regexp.new(/^https:\/\/lob-assets.com\/(order-creatives|letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}([a-z0-9]{10})(_[a-z]{4}_[a-z0-9]{25})(_signature)?(\.pdf|_thumb_[a-z]+_[0-9]+\.png|\.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9_-]+/)
       true
     end
 


### PR DESCRIPTION
The snap pack url regex will reject valid urls that actually come back from the API in production. This change will allow the format of url that I am actually observing when callling the API.

<img width="735" alt="Screenshot 2025-03-06 at 10 46 41 PM" src="https://github.com/user-attachments/assets/34a4d179-4b62-4f2f-8ff9-ec38f3e67456" />
